### PR TITLE
29-Change the color of the focus indicator labels

### DIFF
--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -250,7 +250,7 @@ function MainPage() {
 
     doc.setGState(new doc.GState({opacity: 0.3})); doc.setFillColor(54, 203, 148); doc.rect(36, mapY, 5, 5, 'F'); doc.setGState(new doc.GState({opacity: 1.0}));
     doc.setTextColor(4, 55, 36); doc.setFontSize(5); doc.setFont("helvetica", "bold"); doc.text("OK", 38.5, mapY + 3.5, { align: 'center' });
-    doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("balans", 43, mapY + 3.5);
+    doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("Balans", 43, mapY + 3.5);
 
     doc.setFillColor(147, 51, 234); doc.rect(60, mapY, 5, 5, 'F');
     doc.setTextColor(255, 255, 255); doc.setFontSize(6); doc.setFont("helvetica", "bold"); doc.text("F", 62.5, mapY + 3.5, { align: 'center' });
@@ -452,7 +452,7 @@ function MainPage() {
                             </td>
                             <td>
                               {act.focusState === 'chaos' && <span className="badge badge-warning badge-sm font-bold">Chaos</span>}
-                              {(act.focusState === 'spokój' || !act.focusState) && <span className="badge badge-sm font-bold border" style={{backgroundColor: '#36cb944d', color: '#043724', borderColor: '#36cb944d'}}>balans</span>}
+                              {(act.focusState === 'spokój' || !act.focusState) && <span className="badge badge-sm font-bold border" style={{backgroundColor: '#36cb944d', color: '#043724', borderColor: '#36cb944d'}}>Balans</span>}
                               {act.focusState === 'hiperfokus' && <span className="badge badge-primary badge-sm text-white font-bold">Hiperfokus</span>}
                             </td>
                             <td>
@@ -529,7 +529,7 @@ function MainPage() {
                         <div className="w-5 h-5 bg-warning rounded-full shadow-sm flex items-center justify-center text-white text-[9px] font-bold">CH</div> Chaos
                       </div>
                       <div className="flex items-center gap-2">
-                        <div className="w-5 h-5 rounded-full shadow-sm flex items-center justify-center text-[9px] font-bold" style={{backgroundColor: '#36cb944d', color: '#043724'}}>OK</div> balans
+                        <div className="w-5 h-5 rounded-full shadow-sm flex items-center justify-center text-[9px] font-bold" style={{backgroundColor: '#36cb944d', color: '#043724'}}>OK</div> Balans
                       </div>
                       <div className="flex items-center gap-2">
                         <div className="w-5 h-5 bg-primary rounded-full shadow-sm flex items-center justify-center text-white text-[9px] font-bold">F</div> Hiperfokus

--- a/src/components/WeeklyView.js
+++ b/src/components/WeeklyView.js
@@ -217,7 +217,7 @@ const WeeklyView = ({ db, targetUid, isReadOnly, initialDate }) => {
       const hour = (i + 7) % 24;
       return String(hour).padStart(2, '0');
     });
-    const mapHeadRow = ["Dzien", ...hours];
+    const mapHeadRow = ["Dzien/Godz", ...hours];
 
     const mapRows = DAYS.map((day, index) => {
       const dateObj = getDateFromWeekKey(currentWeekKey, index);
@@ -253,7 +253,7 @@ const WeeklyView = ({ db, targetUid, isReadOnly, initialDate }) => {
       body: mapRows,
       startY: finalY,
       theme: 'grid',
-      headStyles: { fillColor: [255, 255, 255], textColor: [0, 0, 0], halign: 'center', fontSize: 8 },
+      headStyles: { fillColor: [255, 255, 255], textColor: [0, 0, 0], halign: 'center', fontSize: 8, lineWidth: 0.2, lineColor: [180, 180, 180] },
       styles: { fontSize: 8, cellPadding: 1, minCellHeight: 7, halign: 'center', valign: 'middle' },
       columnStyles: {
         0: { cellWidth: 30, halign: 'left', fontStyle: 'bold', fillColor: [255, 255, 255], textColor: [0, 0, 0] }
@@ -269,7 +269,7 @@ const WeeklyView = ({ db, targetUid, isReadOnly, initialDate }) => {
 
     doc.setGState(new doc.GState({opacity: 0.3})); doc.setFillColor(54, 203, 148); doc.rect(36, legendY, 5, 5, 'F'); doc.setGState(new doc.GState({opacity: 1.0}));
     doc.setTextColor(4, 55, 36); doc.setFontSize(5); doc.setFont("helvetica", "bold"); doc.text("OK", 38.5, legendY + 3.5, { align: 'center' });
-    doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("balans", 43, legendY + 3.5);
+    doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("Balans", 43, legendY + 3.5);
 
     doc.setFillColor(147, 51, 234); doc.rect(60, legendY, 5, 5, 'F');
     doc.setTextColor(255, 255, 255); doc.setFontSize(6); doc.setFont("helvetica", "bold"); doc.text("F", 62.5, legendY + 3.5, { align: 'center' });
@@ -386,7 +386,7 @@ const WeeklyView = ({ db, targetUid, isReadOnly, initialDate }) => {
 
         doc.setGState(new doc.GState({opacity: 0.3})); doc.setFillColor(54, 203, 148); doc.rect(36, mapY, 5, 5, 'F'); doc.setGState(new doc.GState({opacity: 1.0}));
         doc.setTextColor(4, 55, 36); doc.setFontSize(5); doc.setFont("helvetica", "bold"); doc.text("OK", 38.5, mapY + 3.5, { align: 'center' });
-        doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("balans", 43, mapY + 3.5);
+        doc.setTextColor(0, 0, 0); doc.setFontSize(8); doc.setFont("helvetica", "normal"); doc.text("Balans", 43, mapY + 3.5);
 
         doc.setFillColor(147, 51, 234); doc.rect(60, mapY, 5, 5, 'F');
         doc.setTextColor(255, 255, 255); doc.setFontSize(6); doc.setFont("helvetica", "bold"); doc.text("F", 62.5, mapY + 3.5, { align: 'center' });
@@ -545,7 +545,7 @@ const WeeklyView = ({ db, targetUid, isReadOnly, initialDate }) => {
         </div>
         <div className="flex flex-wrap items-center justify-center gap-4 text-xs mt-3">
           <div className="flex items-center gap-2"><span className="w-3 h-3 rounded bg-warning inline-block" /><span>Chaos (CH)</span></div>
-          <div className="flex items-center gap-2"><span className="w-3 h-3 rounded inline-block" style={{backgroundColor: '#36cb944d'}} /><span>balans (OK)</span></div>
+          <div className="flex items-center gap-2"><span className="w-3 h-3 rounded inline-block" style={{backgroundColor: '#36cb944d'}} /><span>Balans (OK)</span></div>
           <div className="flex items-center gap-2"><span className="w-3 h-3 rounded bg-primary inline-block" /><span>Hiperfokus (F)</span></div>
           <div className="flex items-center gap-2"><span className="w-3 h-3 rounded bg-base-200 inline-block" /><span>Brak danych</span></div>
         </div>


### PR DESCRIPTION
Closes #29

## Changes
- Updated form labels: "Rozproszenie/chaos" and "Balans/spokój"
- Changed OK indicator colors across all views:
  - Form: restored success color (green DaisyUI)
  - Focus maps (daily/weekly views & PDFs): background #36cb944d, text #043724

## Testing
- ✅ Form radio buttons display correctly
- ✅ Daily focus map shows new colors
- ✅ Weekly focus map table shows new colors
- ✅ PDF exports (daily & weekly) use new colors